### PR TITLE
33: Fixed phone number white spaces issue

### DIFF
--- a/TreeTracker/UI/Views/Authentication/SignIn/SignInViewModel.swift
+++ b/TreeTracker/UI/Views/Authentication/SignIn/SignInViewModel.swift
@@ -96,7 +96,7 @@ private extension SignInViewModel {
         case .email:
             return .email(usernameValue)
         case .phoneNumber:
-            return .phoneNumber(usernameValue)
+            return .phoneNumber(usernameValue.replacingOccurrences(of: " ", with: ""))
         }
     }
 


### PR DESCRIPTION
When you use iOS phone number autofill some spaces often get added to the phone number. We want to filter these out before saving to the database as it can cause issues later on if a user enters the phone number without spaces.

