### PR TITLE
fix: improve images quality

### DIFF
--- a/TreeTracker/Resources/Assets.xcassets/Forest.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Forest.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/GuidenceImagery/gardening.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/GuidenceImagery/gardening.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/GuidenceImagery/phoneViewfinder.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/GuidenceImagery/phoneViewfinder.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/GuidenceImagery/planting.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/GuidenceImagery/planting.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/GuidenceImagery/selfie.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/GuidenceImagery/selfie.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/Key.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/Key.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/Padlock.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/Padlock.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/add.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/add.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/arrow.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/arrow.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/logout.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/logout.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/mail.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/mail.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/note.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/note.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/people.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/people.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/person.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/person.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/phone.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/phone.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/profile.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/profile.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/sapling_Icon.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/sapling_Icon.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/seed.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/seed.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/settings.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/settings.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Icons/upload.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Icons/upload.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
+    "preserves-vector-representation" : true,
     "template-rendering-intent" : "template"
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/LaunchScreenForest.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/LaunchScreenForest.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Logos/LaunchScreenLogo.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Logos/LaunchScreenLogo.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Logos/Logo.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Logos/Logo.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Logos/LogoWithTitle.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Logos/LogoWithTitle.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/Trees.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/Trees.imageset/Contents.json
@@ -17,5 +17,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/gpsSearchAnimation/gps-load-0.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/gpsSearchAnimation/gps-load-0.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/gpsSearchAnimation/gps-load-1.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/gpsSearchAnimation/gps-load-1.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }

--- a/TreeTracker/Resources/Assets.xcassets/gpsSearchAnimation/gps-load-2.imageset/Contents.json
+++ b/TreeTracker/Resources/Assets.xcassets/gpsSearchAnimation/gps-load-2.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "author" : "xcode",
     "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
   }
 }


### PR DESCRIPTION
fix: Improve the quality of images by setting "preserve vector data" to true.

## Overview of changes
I changed all the image resizing box to true

I think that "people" and "person" icons are not vector based because it's still pixelated.
"settings" icon could improve quality with another file with more pixels. It's still pixelated.

## How was the change tested
I tested it with my iphone.

## Screenshots (if applicable)
# Before
![IMG_1727](https://user-images.githubusercontent.com/104015488/220744732-78e97e6a-334e-4301-a537-85d5ca047db0.jpg)

# After
![IMG_1729](https://user-images.githubusercontent.com/104015488/220744741-a8f81585-ba82-4b61-af6d-6db2b18a0ea4.jpg)

# Before
![IMG_1730](https://user-images.githubusercontent.com/104015488/220744941-532b1955-86eb-43ce-86b8-71978ab2bdc3.PNG)

# After
![IMG_1731](https://user-images.githubusercontent.com/104015488/220745041-aeb98144-8bbf-4605-94f1-630ddd7257c9.PNG)

# Still creepy
![IMG_1728](https://user-images.githubusercontent.com/104015488/220745811-e0211735-d851-4de9-8164-65d9392c74c1.jpg)




