### PR TITLE
Fix: issue #111 - extra character on email text field

### DIFF
--- a/TreeTracker/UI/Views/Authentication/SignIn/SignInViewController.swift
+++ b/TreeTracker/UI/Views/Authentication/SignIn/SignInViewController.swift
@@ -68,6 +68,9 @@ class SignInViewController: UIViewController, KeyboardDismissing, AlertPresentin
 private extension SignInViewController {
 
     @IBAction func logInButtonPressed() {
+        guard let newText = usernameTextField.text else { return }
+        viewModel?.updateUsername(username: newText)
+        
         viewModel?.login()
     }
 

--- a/TreeTracker/UI/Views/Authentication/SignIn/SignInViewController.swift
+++ b/TreeTracker/UI/Views/Authentication/SignIn/SignInViewController.swift
@@ -21,6 +21,7 @@ class SignInViewController: UIViewController, KeyboardDismissing, AlertPresentin
             usernameTextField.textContentType = .telephoneNumber
             usernameTextField.keyboardType = .phonePad
             usernameTextField.returnKeyType = .done
+            usernameTextField.autocorrectionType = .no
             usernameTextField.placeholder = L10n.SignIn.TextInput.PhoneNumber.placeholder
             usernameTextField.validationState = .normal
         }


### PR DESCRIPTION
## Overview of changes
- Fix issue #111 . There's no more extra character on emailTextField.
- Removed the red dotted line in emailTextField that was not helping at all. (auto-correction)

## How was the change tested
- Tested on my device

## Screenshots (if applicable)

https://user-images.githubusercontent.com/104015488/220756697-690722eb-b6a6-4f43-91ca-be2cc7e37374.MP4

