### PR TITLE
Fix: #110 - photo quality update to the default value when the user delete the account.

### DIFF
--- a/TreeTracker/UI/Navigation/Home/HomeCoordinator.swift
+++ b/TreeTracker/UI/Navigation/Home/HomeCoordinator.swift
@@ -146,7 +146,8 @@ private extension HomeCoordinator {
                 planter: planter,
                 selfieService: self.treetrackerSDK.selfieService,
                 uploadManager: self.treetrackerSDK.uploadManager,
-                userDeletionService: self.treetrackerSDK.userDeletionService
+                userDeletionService: self.treetrackerSDK.userDeletionService,
+                settingsService: self.treetrackerSDK.settingsService
             )
             viewModel.coordinatorDelegate = self
             return viewModel

--- a/TreeTracker/UI/Views/Profile Screen/ProfileViewModel.swift
+++ b/TreeTracker/UI/Views/Profile Screen/ProfileViewModel.swift
@@ -28,17 +28,20 @@ class ProfileViewModel {
     private let selfieService: Treetracker_Core.SelfieService
     private let uploadManager: Treetracker_Core.UploadManaging
     private let userDeletionService: Treetracker_Core.UserDeletionService
+    private let settingsService: Treetracker_Core.SettingsService
 
     init(
         planter: Treetracker_Core.Planter,
         selfieService: Treetracker_Core.SelfieService,
         uploadManager: Treetracker_Core.UploadManaging,
-        userDeletionService: Treetracker_Core.UserDeletionService
+        userDeletionService: Treetracker_Core.UserDeletionService,
+        settingsService: Treetracker_Core.SettingsService
     ) {
         self.planter = planter
         self.selfieService = selfieService
         self.uploadManager = uploadManager
         self.userDeletionService = userDeletionService
+        self.settingsService = settingsService
     }
 
     var title: String {
@@ -80,6 +83,7 @@ class ProfileViewModel {
     func deleteAccount() {
 
         do {
+            settingsService.update(value: PhotoQuality.medium.photoSize, forSetting: .treePhotoSize)
             try userDeletionService.deletePlanter(planter: planter)
             if uploadManager.isUploading {
                 uploadManager.stopUploading()

--- a/TreeTracker/UI/Views/Profile Screen/ProfileViewModel.swift
+++ b/TreeTracker/UI/Views/Profile Screen/ProfileViewModel.swift
@@ -83,8 +83,8 @@ class ProfileViewModel {
     func deleteAccount() {
 
         do {
-            settingsService.update(value: PhotoQuality.medium.photoSize, forSetting: .treePhotoSize)
             try userDeletionService.deletePlanter(planter: planter)
+            settingsService.update(value: PhotoQuality.medium.photoSize, forSetting: .treePhotoSize)
             if uploadManager.isUploading {
                 uploadManager.stopUploading()
             }


### PR DESCRIPTION
## Overview of changes
- #110 

## How was the change tested
In the simulator creating an account, changing photo quality to high, deleting the account and creating another.

## Screenshots (if applicable)
